### PR TITLE
Add an optional "collectionViewBounces" configuration parameter

### DIFF
--- a/Example/Example (macOS)/ContentView.swift
+++ b/Example/Example (macOS)/ContentView.swift
@@ -8,7 +8,7 @@ struct ContentView: View {
 
     @State var values: [Int] = Array(stride(from: 0, through: 100, by: 5))
     
-    let ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE = true
+    let enableUnderlyingCollectionViewBounce = true
 
     var body: some View {
         VStack {
@@ -29,7 +29,7 @@ struct ContentView: View {
             GeometryReader { proxy in
                 WheelPicker(values,
                             selected: $selected,
-                            collectionViewBounces: ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE,
+                            collectionViewBounces: enableUnderlyingCollectionViewBounce,
                             centerSize: center,
                             cell: {
                                 Text("\($0)")

--- a/Example/Example (macOS)/ContentView.swift
+++ b/Example/Example (macOS)/ContentView.swift
@@ -7,6 +7,8 @@ struct ContentView: View {
     @State var selected: Int = 50
 
     @State var values: [Int] = Array(stride(from: 0, through: 100, by: 5))
+    
+    let ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE = true
 
     var body: some View {
         VStack {
@@ -27,6 +29,7 @@ struct ContentView: View {
             GeometryReader { proxy in
                 WheelPicker(values,
                             selected: $selected,
+                            collectionViewBounces: ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE,
                             centerSize: center,
                             cell: {
                                 Text("\($0)")

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -20,7 +20,7 @@ struct ContentView: View {
         stride(from: 0, through: 100, by: 1).map { Value.init(index: $0, length: self.length) }
     }
     
-    let ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE = false
+    let enableUnderlyingCollectionViewBounce = false
 
     var body: some View {
         VStack {
@@ -41,7 +41,7 @@ struct ContentView: View {
             GeometryReader { proxy in
                 WheelPicker(values,
                             selected: $selected,
-                            collectionViewBounces: ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE,
+                            collectionViewBounces: enableUnderlyingCollectionViewBounce,
                             centerSize: length / 10 + 1,
                             cell: {
                                 Text("\($0.index) - \($0.length)")

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -19,6 +19,8 @@ struct ContentView: View {
     var values: [Value] {
         stride(from: 0, through: 100, by: 1).map { Value.init(index: $0, length: self.length) }
     }
+    
+    let ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE = false
 
     var body: some View {
         VStack {
@@ -39,6 +41,7 @@ struct ContentView: View {
             GeometryReader { proxy in
                 WheelPicker(values,
                             selected: $selected,
+                            collectionViewBounces: ENABLE_UNDERLYING_COLLECTIONVIEW_BOUNCE,
                             centerSize: length / 10 + 1,
                             cell: {
                                 Text("\($0.index) - \($0.length)")

--- a/Sources/WheelPicker/CollectionPickerView.swift
+++ b/Sources/WheelPicker/CollectionPickerView.swift
@@ -86,7 +86,7 @@ where Value: Comparable {
 
     init(values: [Value],
          selected: Value,
-         collectionViewBounces: Bool? = true,
+         collectionViewBounces: Bool,
          configureCell: @escaping (Cell, Value) -> Void,
          configureCenter: @escaping (Center, Value) -> Void) {
         self.configureCell = configureCell
@@ -104,7 +104,7 @@ where Value: Comparable {
         cv.canCancelContentTouches = true
         cv.delegate = self
         cv.dataSource = self.diffDataSource
-        cv.bounces = collectionViewBounces ?? true
+        cv.bounces = collectionViewBounces
         cv.isScrollEnabled = true
         cv.showsHorizontalScrollIndicator = false
         cv.showsVerticalScrollIndicator = false

--- a/Sources/WheelPicker/CollectionPickerView.swift
+++ b/Sources/WheelPicker/CollectionPickerView.swift
@@ -86,6 +86,7 @@ where Value: Comparable {
 
     init(values: [Value],
          selected: Value,
+         collectionViewBounces: Bool? = true,
          configureCell: @escaping (Cell, Value) -> Void,
          configureCenter: @escaping (Center, Value) -> Void) {
         self.configureCell = configureCell
@@ -103,6 +104,7 @@ where Value: Comparable {
         cv.canCancelContentTouches = true
         cv.delegate = self
         cv.dataSource = self.diffDataSource
+        cv.bounces = collectionViewBounces ?? true
         cv.isScrollEnabled = true
         cv.showsHorizontalScrollIndicator = false
         cv.showsVerticalScrollIndicator = false

--- a/Sources/WheelPicker/PickerWrapper.swift
+++ b/Sources/WheelPicker/PickerWrapper.swift
@@ -7,6 +7,7 @@ struct PickerWrapper<Cell: View, Center: View, Value: Hashable>: UIViewRepresent
     @Binding var selected: Value
 
     let centerSize: Int
+    let collectionViewBounces: Bool
 
     let cell: (Value) -> Cell
     let center: (Value) -> Center
@@ -15,11 +16,13 @@ struct PickerWrapper<Cell: View, Center: View, Value: Hashable>: UIViewRepresent
 
     init(_ values: [Value],
          selected: Binding<Value>,
+         collectionViewBounces: Bool? = true,
          centerSize: Int = 1,
          cell: @escaping (Value) -> Cell,
          center: @escaping (Value) -> Center) {
         self.values = values
         self._selected = selected
+        self.collectionViewBounces = collectionViewBounces ?? true
         self.cell = cell
         self.center = center
         self.centerSize = centerSize
@@ -36,6 +39,7 @@ struct PickerWrapper<Cell: View, Center: View, Value: Hashable>: UIViewRepresent
     func makeUIView(context: Context) -> UIViewType {
         let picker = UIViewType(values: self.values,
                                 selected: self.selected,
+                                collectionViewBounces: self.collectionViewBounces,
                                 configureCell: { $0.set(value: self.cell($1)) },
                                 configureCenter: { $0.set(value: self.center($1)) })
         picker.centerSize = self.centerSize

--- a/Sources/WheelPicker/WheelPicker.swift
+++ b/Sources/WheelPicker/WheelPicker.swift
@@ -6,24 +6,27 @@ public struct WheelPicker<Cell: View, Center: View, Value: Hashable>: View where
     @Binding var selected: Value
 
     let centerSize: Int
+    let collectionViewBounces: Bool
 
     let cell: (Value) -> Cell
     let center: (Value) -> Center
 
     public init(_ values: [Value],
                 selected: Binding<Value>,
+                collectionViewBounces: Bool? = true,
                 centerSize: Int = 1,
                 cell: @escaping (Value) -> Cell,
                 center: @escaping (Value) -> Center) {
         self.values = values
         self._selected = selected
+        self.collectionViewBounces = collectionViewBounces ?? true
         self.cell = cell
         self.center = center
         self.centerSize = centerSize
     }
 
     public var body: some View {
-        PickerWrapper(values, selected: $selected, centerSize: centerSize, cell: cell, center: center)
+        PickerWrapper(values, selected: $selected, collectionViewBounces: collectionViewBounces, centerSize: centerSize, cell: cell, center: center)
     }
 }
 


### PR DESCRIPTION
While investigating what's causing glitchy behaviour when you inertia-scroll up or down past the first or last item in the list (in this case touch interaction is ignored until animated return to first / last cell has completed), I found a way to bypass this issue by disabling "bounce" behaviour of underlying UICollectionView.

I've added an optional parameter to initialiser that allows to set "bounces" attribute of a UICollectionView, with a default behaviour set to "true".

I've also updated examples for iOS and macOS showing how this could be utilised.